### PR TITLE
Added '.start' when cancelling blocked 'F[Sync]' created with 'bracketCase'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 
 scalaVersion := "2.12.7"
 
-libraryDependencies += "org.typelevel" %% "cats-effect" % "1.0.0" withSources() withJavadoc()
+libraryDependencies += "org.typelevel" %% "cats-effect" % "1.2.0" withSources() withJavadoc()
 
 scalacOptions ++= Seq(
   "-feature",

--- a/src/main/scala/catsEffectTutorial/EchoServerV2_GracefulStop.scala
+++ b/src/main/scala/catsEffectTutorial/EchoServerV2_GracefulStop.scala
@@ -92,7 +92,7 @@ object EchoServerV2_GracefulStop extends IOApp {
       stopFlag    <- MVar[F].empty[Unit]
       serverFiber <- serve(serverSocket, stopFlag).start // Server runs on its own Fiber
       _           <- stopFlag.read                       // Blocked until 'stopFlag.put(())' is run
-      _           <- serverFiber.cancel                  // Stopping server!
+      _           <- serverFiber.cancel.start            // Stopping server!
     } yield ExitCode.Success
 
   override def run(args: List[String]): IO[ExitCode] = {

--- a/src/main/scala/catsEffectTutorial/EchoServerV3_ClosingClientsOnShutdown.scala
+++ b/src/main/scala/catsEffectTutorial/EchoServerV3_ClosingClientsOnShutdown.scala
@@ -102,7 +102,7 @@ object EchoServerV3_ClosingClientsOnShutdown extends IOApp {
       stopFlag    <- MVar[F].empty[Unit]
       serverFiber <- serve(serverSocket, stopFlag).start // Server runs on its own Fiber
       _           <- stopFlag.read                       // Blocked until 'stopFlag.put(())' is run
-      _           <- serverFiber.cancel                  // Stopping server!
+      _           <- serverFiber.cancel.start            // Stopping server!
     } yield ExitCode.Success
 
   override def run(args: List[String]): IO[ExitCode] = {

--- a/src/main/scala/catsEffectTutorial/EchoServerV4_ClientThreadPool.scala
+++ b/src/main/scala/catsEffectTutorial/EchoServerV4_ClientThreadPool.scala
@@ -112,7 +112,7 @@ object EchoServerV4_ClientThreadPool extends IOApp {
       serverFiber <- serve(serverSocket, stopFlag).start         // Server runs on its own Fiber
       _           <- stopFlag.read                               // Blocked until 'stopFlag.put(())' is run
       _           <- Sync[F].delay(clientsThreadPool.shutdown()) // Shutting down clients pool
-      _           <- serverFiber.cancel                          // Stopping server
+      _           <- serverFiber.cancel.start                    // Stopping server
     } yield ExitCode.Success
 
   }

--- a/src/main/scala/catsEffectTutorial/EchoServerV5_Async.scala
+++ b/src/main/scala/catsEffectTutorial/EchoServerV5_Async.scala
@@ -118,7 +118,7 @@ object EchoServerV5_Async extends IOApp {
       serverFiber <- serve(serverSocket, stopFlag).start         // Server runs on its own Fiber
       _           <- stopFlag.read                               // Blocked until 'stopFlag.put(())' is run
       _           <- Sync[F].delay(clientsThreadPool.shutdown()) // Shutting down clients pool
-      _           <- serverFiber.cancel                          // Stopping server
+      _           <- serverFiber.cancel.start                    // Stopping server
     } yield ExitCode.Success
 
   }


### PR DESCRIPTION
In cats-effect 1.1.0/1.2.0 behavior of `cancel` changed. Now canceling waits on the release function to finish. If the `IO` is blocked, then the `cancel`  call gets blocked too. This can be solved just by adding `.start` to the `.cancel` call.

This is the log of the gitter chat where I present the question and the answer from Alex Nedelcu (27th Jan 2019):

**Luis Rodero**: _"Hi, I'd appreciate if you could help me with this. I'm observing that trying to cancel a fiber that runs a blocked F[Sync] created with bracket blocks the caller. This happens for cats-effect 1.1.0/1.2.0. The same call does not block the caller in 1.0.0. Is this desired/expected? I can post a brief snippet that shows this behavior."_

**Alexandru Nedelcu**: _"The behavior from 1.0.0 changed, yes, calling cancel awaits for any installed finalizers to finish. If you don't want that, then you can just start and ignore the result."_